### PR TITLE
Update to blackbox 0.12.0. Add libadwaita override for 1.2.beta.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "blackbox-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654745531,
-        "narHash": "sha256-X/cr3fjmzhtHJHliMtxlUQP3KssEh/B8ZeeZyWyuD/8=",
+        "lastModified": 1660669382,
+        "narHash": "sha256-8u4qHC8+3rKDFNdg5kI48dBgAm3d6ESXN5H9aT/nIBY=",
         "ref": "main",
-        "rev": "e0f2fbfcde64251a0083715c295cd91ba6e0a2a1",
-        "revCount": 107,
+        "rev": "c9ed9fd1e50b5be15ed0529e3536c63aa4b23553",
+        "revCount": 247,
         "type": "git",
         "url": "https://gitlab.gnome.org/raggesilver/blackbox"
       },
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655400192,
-        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
+        "lastModified": 1660819943,
+        "narHash": "sha256-TRZV/mlW1eYuojqDC3ueYWj7jsTKXJCtyMLNYX/Ybtw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
+        "rev": "8ea014acc33da95ea56c902229957d8225005163",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     "vte-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652120268,
-        "narHash": "sha256-VsRrww0KpQbDQH7ClAoocLzhR0grNPKZvYcCJFdYqaU=",
+        "lastModified": 1660860193,
+        "narHash": "sha256-Th7Jlll9DIGuB4dySAfTGI6TXyTl0AfRE0EgT0exrJs=",
         "ref": "master",
-        "rev": "b51feeca889d4b597e95b21bc77dc078892af11d",
-        "revCount": 5173,
+        "rev": "b4abc09b0950e2b1593782116b7fa9fc2e7ffba1",
+        "revCount": 5209,
         "type": "git",
         "url": "https://gitlab.gnome.org/gnome/vte"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,26 @@
 
   outputs = inputs: let
     system = "x86_64-linux";
-    pkgs = inputs.nixpkgs.legacyPackages.${system};
+    overlays = [inputs.self.overlays.default];
+    pkgs = import inputs.nixpkgs {inherit overlays system;};
   in {
+    overlays = {
+      blackbox = final: prev: {
+        # Requires libadwaita 1.2, but nixpkgs doesn't have this yet.
+        libadwaita = prev.libadwaita.overrideAttrs (old: rec {
+          version = "1.2.beta";
+          src = prev.fetchFromGitLab {
+            domain = "gitlab.gnome.org";
+            owner = "GNOME";
+            repo = "libadwaita";
+            rev = version;
+            hash = "sha256-QBblkeNAgfHi5YQxaV9ceqNDyDIGu8d6pvLcT6apm6o=";
+          };
+        });
+      };
+      default = inputs.self.overlays.blackbox;
+    };
+
     packages.${system} = rec {
       vte-gtk4 = pkgs.callPackage ./vte-gtk4.nix {
         inherit (inputs) vte-src;


### PR DESCRIPTION
The libadwaita override is required as blackbox 0.12 requires libadwaita 1.2 or greater, though nixpkgs unstable only hosts 1.1.4.