### PR TITLE
Update url of patch to fix launch

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation {
   patches = [
     (fetchpatch {
       name = "yilozt_launch_fix.diff";
-      url = https://raw.githubusercontent.com/yilozt/pkgbuilds/main/terminal-gtk4-git/launch_fix.diff;
-      sha256 = "sha256-nrA9Fdr++B11h5LedBfvebGxK92HTzdyuSBOOSY3Z44=";
+      url = https://raw.githubusercontent.com/yilozt/pkgbuilds/main/blackbox-terminal-git/launch_fix.diff;
+      sha256 = "sha256-/9aNLSrKg8IY6CvQHzfmGu9PnN5ik/cCYPZ1XgkgOSQ=";
     })
   ];
   postPatch = ''


### PR DESCRIPTION
Package `terminal-gtk4-git` in AUR has been renamed to `blackbox-terminal-git`, so the url of patch should be updated.

New patch will force blackbox read padding values from gsettings, so it can fix crash when right click in terminal.

Ref: https://aur.archlinux.org/packages/blackbox-terminal-git#comment-880093
Related: https://github.com/NixOS/nixpkgs/pull/189425
cc @chuangzhu